### PR TITLE
#4 fix ut compile under GOMODULE11 set on

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/cosmwasm/cosmwasm-go
+
+go 1.12
+
+require github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/poc/ext/jsonparser/go.mod
+++ b/poc/ext/jsonparser/go.mod
@@ -1,3 +1,0 @@
-module github.com/buger/jsonparser
-
-go 1.13

--- a/poc/ext/vjson/go.mod
+++ b/poc/ext/vjson/go.mod
@@ -1,1 +1,0 @@
-module github.com/vugu/vjson

--- a/poc/src/contract_test.go
+++ b/poc/src/contract_test.go
@@ -8,6 +8,10 @@ import (
 	"testing"
 )
 
+func db_read(key, value int) int{
+	return 100
+}
+
 func TestAllocate(t *testing.T) {
 	result := std.Package_message([]byte("1234567"))
 	_ = result
@@ -16,9 +20,9 @@ func TestAllocate(t *testing.T) {
 func TestInit(t *testing.T){
 
 	msg := InitMsg{
-		Verifier:    "AAAAAA",
-		Beneficiary: "BBBBBB",
-		Legacy:      1100,
+		UserName:    "AAAAAA",
+		Password: "BBBBBB",
+		Money:      1100,
 	}
 	msg_alloc := allocate(1000)
 	msg_str,e := ezjson.Marshal(msg)


### PR DESCRIPTION
Delete ext depends go.mod file to fix the issue #4 
UT are still unusable , because we are using a import func that exported by cosmwasm-vm, it can not run in go test.
BTW: ext package need move to extern too and use it as a submodule,we must make a new repo for develop on jsonparser and vjosn lib