### PR TITLE
Document how to build tinygo for contract compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,22 @@ The following produces the same sha256 hash everytime I run it:
 
 ```
 cd example/hackatom
-make build && sha256sum hackatom.wasm 
+make build && sha256sum hackatom.wasm
+
+# this will test the wasm code
+go test ./integration
 ```
+
+However, the docker image for our custom TinyGo is not yet published.
+In order to build locally you can do the following:
+
+```
+git clone https://github.com/confio/tinygo.git
+git checkout cw-0.19.0
+docker build -t cosmwasm/tinygo:0.19.0 -f Dockerfile.wasm .
+```
+
+Once it is finished, you should be able to successfully run `make build` on hackatom
 
 ## Performance
 

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -3,7 +3,7 @@
 set -o errexit -o nounset -o pipefail
 command -v shellcheck > /dev/null && shellcheck "$0"
 
-TINYGO_IMAGE="cosmwasm/tinygo:0.19.0-dev2"
+TINYGO_IMAGE="cosmwasm/tinygo:0.19.0"
 EMSCRIPTEN="polkasource/webassembly-wabt:v1.0.11"
 
 SCRIPT_DIR="$(realpath "$(dirname "$0")")"
@@ -12,7 +12,7 @@ ROOT="$(dirname "$SCRIPT_DIR")"
 function print_usage() {
   echo "Usage: $0 [contract_name]"
   echo ""
-  echo "e.g. $0 erc20"
+  echo "e.g. $0 hackatom"
   echo "This must be a valid directory name under example/"
 }
 


### PR DESCRIPTION
Show how to build `cosmwasm/tinygo:0.19.0` if it is not yet published for your platform